### PR TITLE
Fix parse_udp function description and variables naming

### DIFF
--- a/sample_4_1/xdp_vxlan_kern.c
+++ b/sample_4_1/xdp_vxlan_kern.c
@@ -49,7 +49,7 @@ static inline int parse_ipv4(void *data, __u64 *nh_off, void *data_end,
 
 /* Parse UDP packet to get source port, destination port and UDP header size */
 static inline int parse_udp(void *data, __u64 th_off, void *data_end,
-			     __be16 *src, __be16 *dest)
+			     __be16 *src_port, __be16 *dest_port)
 {
 	struct udphdr *uh = data + th_off;
 
@@ -60,8 +60,8 @@ static inline int parse_udp(void *data, __u64 th_off, void *data_end,
 	if (uh->check)
 		return 0;
 
-	*src = uh->source;
-	*dest = uh->dest;
+	*src_port = uh->source;
+	*dest_port = uh->dest;
 	return __constant_ntohs(uh->len);
 }
 

--- a/sample_4_1/xdp_vxlan_kern.c
+++ b/sample_4_1/xdp_vxlan_kern.c
@@ -47,7 +47,7 @@ static inline int parse_ipv4(void *data, __u64 *nh_off, void *data_end,
 	return iph->protocol;
 }
 
-/* Parse IPV4 packet to get SRC, DST IP and protocol */
+/* Parse UDP packet to get source port, destination port and UDP header size */
 static inline int parse_udp(void *data, __u64 th_off, void *data_end,
 			     __be16 *src, __be16 *dest)
 {


### PR DESCRIPTION
Hi, 

this is a small Pull Request which has the following contributions:

1. Fix the description of the `parse_udp` function that was not describing what it does;
2. Updates variables names to simplify understanding what is happening inside the function;

Thank you for this project. It has really helpful content and code! 